### PR TITLE
build(s4): set deps of PyTorch 2.5.1 and CUDA 12.4 for Colab #6 #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ conda install pytorch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1 pytorch-cud
 pip install -r requirements.txt
 ```
 
+#### Requirements in 2025
+PyTorch doesn't support Anaconda anymore, and the latest CUDA is preferred.
+Three phases of advancing the dependencies to the latest:
+1. CUDA 12.4, PyTorch 2.5.1, Python 3.11
+2. CUDA 12.6, PyTorch 2.6.0, Python 3.12
+3. CUDA 12.8, PyTorch 2.7.0, Python 3.13
+
+So new example installation (TBA):
+```sh
+# (TBA) A script that helps install CUDA on a Ubuntu 22.04 machine.
+```
+```sh
+pip install -r requirements.txt
+```
+
+The three phases will be verified on Colab with [notebooks/colab.ipynb](notebooks/colab.ipynb).
 
 ### Structured Kernels
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,4 @@
+torch @ https://download.pytorch.org/whl/cu124/torch-2.5.1%2Bcu124-cp311-cp311-linux_x86_64.whl
+torchaudio @ https://download.pytorch.org/whl/cu124/torchaudio-2.5.1%2Bcu124-cp311-cp311-linux_x86_64.whl
+torchvision @ https://download.pytorch.org/whl/cu124/torchvision-0.20.1%2Bcu124-cp311-cp311-linux_x86_64.whl
+# torchtext  # Now we have to compile it manually

--- a/notebooks/colab.ipynb
+++ b/notebooks/colab.ipynb
@@ -1,0 +1,234 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Verify Original Status of Colab\n",
+        "The cell outputs in this section is for reference."
+      ],
+      "metadata": {
+        "id": "NpkmRKCdD50d"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!python -V"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "B2ni0q7k8Ybz",
+        "outputId": "f5b1b3d6-95ac-4f70-a20e-758ef68ec8a2"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Python 3.11.11\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip list | grep torch"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "lJ2onFwk8TcE",
+        "outputId": "aa745bc8-4e0e-4e95-c195-cfb727d4396f"
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch                              2.5.1+cu124\n",
+            "torchaudio                         2.5.1+cu124\n",
+            "torchsummary                       1.5.1\n",
+            "torchvision                        0.20.1+cu124\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Known Issues of Colab"
+      ],
+      "metadata": {
+        "id": "74dv7s4gEVdf"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#### 1. Inconsistent `nvidia` Packages\n",
+        "They will be fixed by `pip install` soon."
+      ],
+      "metadata": {
+        "id": "9QjnHAcuGOON"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip check"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "qXBS_JLVDtKS",
+        "outputId": "c45cfc61-5df7-457e-a7fb-42ac6218c323"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "ipython 7.34.0 requires jedi, which is not installed.\n",
+            "pygobject 3.42.1 requires pycairo, which is not installed.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-cublas-cu12==12.4.5.8; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-cublas-cu12 12.5.3.2.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-cuda-cupti-cu12==12.4.127; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-cuda-cupti-cu12 12.5.82.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-cuda-nvrtc-cu12==12.4.127; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-cuda-nvrtc-cu12 12.5.82.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-cuda-runtime-cu12==12.4.127; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-cuda-runtime-cu12 12.5.82.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-cudnn-cu12==9.1.0.70; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-cudnn-cu12 9.3.0.75.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-cufft-cu12==11.2.1.3; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-cufft-cu12 11.2.3.61.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-curand-cu12==10.3.5.147; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-curand-cu12 10.3.6.82.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-cusolver-cu12==11.6.1.9; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-cusolver-cu12 11.6.3.83.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-cusparse-cu12==12.3.1.170; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-cusparse-cu12 12.5.1.3.\n",
+            "torch 2.5.1+cu124 has requirement nvidia-nvjitlink-cu12==12.4.127; platform_system == \"Linux\" and platform_machine == \"x86_64\", but you have nvidia-nvjitlink-cu12 12.5.82.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#### 2. Mismatch and Unknown Linux Headers\n",
+        "It prevents `dkms` from updating display drivers; seems no way to be resolved."
+      ],
+      "metadata": {
+        "id": "V286vm7qF7BO"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!uname -r  # 6.1.85+ is unknown\n",
+        "!ls /usr/src  # 5.15.0 is common for Ubuntu 22.04"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WfnkSJdUFaY0",
+        "outputId": "e997d70e-5590-4a44-817c-af0c7f322276"
+      },
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "6.1.85+\n",
+            "linux-headers-5.15.0-131  linux-headers-5.15.0-131-generic  python3.10\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Update Dependencies"
+      ],
+      "metadata": {
+        "id": "N3V-UnImHA46"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The hard-coded repo and branch below should be changed in the future.\n",
+        "\n",
+        "**One should also not clone from branch after each merge of PR.**"
+      ],
+      "metadata": {
+        "id": "wKPIeQVN7W65"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "1t6nnWPh8leT"
+      },
+      "outputs": [],
+      "source": [
+        "%cd /content\n",
+        "!rm -rf s4\n",
+        "!git clone -b build/deps-pt251_cu124 https://github.com/cataluna84/s4.git\n",
+        "#!git clone https://github.com/cataluna84/s4.git"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%cd /content/s4"
+      ],
+      "metadata": {
+        "id": "pEV4M5Jn7_ht"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -r requirements.txt"
+      ],
+      "metadata": {
+        "id": "CUJMQv8Y9rV9"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip check"
+      ],
+      "metadata": {
+        "id": "ZOiy5ofc8N78"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,32 @@
-numpy
-scipy
-pandas
-scikit-learn
-matplotlib
-tqdm
-rich
-torchtext
-lit # Getting installation errors with torch 2.0 if this isn't installed
-# torchvision
-pytorch-lightning==2.0.4
-hydra-core
-omegaconf
-wandb
-einops
-cmake # For pykeops support
+-c constraints.txt
+
+numpy>=1.26.4,<1.27
+scipy>=1.13.1,<1.14
+pandas>=2.2.2,<2.3
+scikit-learn>=1.6.1,<1.7
+matplotlib>=3.10.0,<3.11
+tqdm>=4.67.1,<4.68
+rich>=13.9.4,<13.10
+ninja>=1.11.1.3,<1.12  # For manual compilation of `torchtext`
+lit>=18.1.8,<18.2  # Getting installation errors with torch 2.0 if this isn't installed
+pytorch-lightning>=2.5.0,<2.6.0
+hydra-core>=1.3.2,<1.4
+omegaconf>=2.3.0,<2.4
+wandb>=0.19.6,<0.20.0
+einops>=0.8.0,<0.9
+cmake>=3.31.4,<3.32  # For pykeops support
 # pykeops # Seems to cause various issues; leaving uninstalled by default
-transformers # For some schedulers
+transformers>=4.48.2,<4.49  # For some schedulers
 
 # Model specific packges
 # pytorch-fast-transformers # for Performer
 
 # Dataset specific packages
-datasets # LRA
-sktime # BIDMC
-scikit-learn # Impedance
-numba # Impedance
-gluonts # Monash
-timm==0.5.4 # ImageNet
+datasets>=3.2.0,<3.3  # LRA
+sktime>=0.36.0,<0.37  # BIDMC
+# scikit-learn>=1.6.1,<1.7  # Impedance; redundant
+numba>=0.61.0,<0.62  # Impedance
+gluonts>=0.16.0,<0.17  # Monash
+timm>=1.0.14,<1.1  # ImageNet
+
+gcsfs<2024.10.0  # For datasets on Colab


### PR DESCRIPTION
- close: #6

As #6 described, the DoD is simple: no broken pip deps on Colab.

More child PRs will be stacked on this one.