### PR TITLE
feat(s4): enable IMDB training with 0.1 vld set on Colab #8 #5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: autoformat lint dev lib torchtext
+
+.ONESHELL:
+
 autoformat:
 	black src/ checkpoints/ models/
 	isort --atomic src/ checkpoints/ models/
@@ -10,3 +14,12 @@ lint:
 
 dev:
 	pip install -r requirements-dev.txt
+
+lib:
+	pip install -r requirements.txt
+
+torchtext: lib
+	git clone https://github.com/pytorch/text build/torchtext
+	cd build/torchtext
+	git submodule update --init --recursive
+	python setup.py clean install

--- a/notebooks/colab.ipynb
+++ b/notebooks/colab.ipynb
@@ -193,7 +193,7 @@
       "source": [
         "%cd /content\n",
         "!rm -rf s4\n",
-        "!git clone -b build/deps-pt251_cu124 https://github.com/cataluna84/s4.git\n",
+        "!git clone -b feat/imdb-pt251_cu124_py311 https://github.com/cataluna84/s4.git\n",
         "#!git clone https://github.com/cataluna84/s4.git"
       ]
     },
@@ -226,6 +226,105 @@
       ],
       "metadata": {
         "id": "ZOiy5ofc8N78"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Install `torchtext`\n",
+        "Compiling `torchtext` will take about 4.5 minutes.\n",
+        "\n",
+        "**Caveat**: This compilation may change some CUDA deps."
+      ],
+      "metadata": {
+        "id": "LbLV2pOXmyHG"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!make torchtext"
+      ],
+      "metadata": {
+        "id": "_DgmL6nfClAc"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip list | grep torch"
+      ],
+      "metadata": {
+        "id": "coi9xCTI2c1X"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip check"
+      ],
+      "metadata": {
+        "id": "Um2uruGZBpyf"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Train S4 with IMDB"
+      ],
+      "metadata": {
+        "id": "zbHM_k-anw7Y"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Remember to put your own W&B API key to Colab's Secrets."
+      ],
+      "metadata": {
+        "id": "ibNcvlaynulo"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import userdata\n",
+        "\n",
+        "\n",
+        "wandb_api_key = userdata.get(\"WANDB_API_KEY\")"
+      ],
+      "metadata": {
+        "id": "AyjNjDw_oUFT"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%env WANDB_API_KEY={wandb_api_key}"
+      ],
+      "metadata": {
+        "id": "2GXe9kqRvHSt"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!python -m train pipeline=imdb model=s4 dataset.val_split=0.1"
+      ],
+      "metadata": {
+        "id": "CSC32E8BA3Ri"
       },
       "execution_count": null,
       "outputs": []

--- a/src/dataloaders/lra.py
+++ b/src/dataloaders/lra.py
@@ -10,6 +10,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 import torchtext
+from torchtext.vocab import build_vocab_from_iterator
 import torchvision
 from einops.layers.torch import Rearrange, Reduce
 from PIL import Image  # Only used for Pathfinder
@@ -115,7 +116,7 @@ class IMDB(SequenceDataset):
             load_from_cache_file=False,
             num_proc=max(self.n_workers, 1),
         )
-        vocab = torchtext.vocab.build_vocab_from_iterator(
+        vocab = build_vocab_from_iterator(
             dataset["train"]["tokens"],
             min_freq=self.min_freq,
             specials=(


### PR DESCRIPTION
- close: #8

DoD: `notebooks/colab.ipynb` should successfully train and submit logs to https://wandb.ai/barabbas-independent/hippo/runs/c99o0nwq as #8 said

<!-- start git-machete generated -->

# Based on PR #7

## Chain of upstream PRs as of 2025-02-09

* PR #7:
  `main` ← `build/deps-pt251_cu124`

  * **PR #13 (THIS ONE)**:
    `build/deps-pt251_cu124` ← `feat/imdb-pt251_cu124_py311`

<!-- end git-machete generated -->
