### PR TITLE
build(s4): add make targets of cu126 and pt260 #9 #5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: autoformat lint dev lib torchtext
+.PHONY: autoformat lint dev lib torchtext cu126 pt260
 
 .ONESHELL:
 
@@ -23,3 +23,28 @@ torchtext: lib
 	cd build/torchtext
 	git submodule update --init --recursive
 	python setup.py clean install
+
+cu126:
+	#nvcc -V  # See original CUDA versions
+	sudo apt-get update
+	#sudo dpkg -l | grep -E "nvidia|cuda"  # See related packages
+	sudo apt-get --allow-change-held-packages --purge remove "nvidia*" "libnvidia-*" "*cublas*" "cuda*" "nsight*"
+	sudo rm -rf /usr/bin/nvidia*
+	sudo rm -rf /usr/lib64-nvidia/*  # This path is Colab's weird choice and the folder is locked by other processes
+	sudo rm -rf /opt/nvidia
+	sudo rm -rf /opt/bin/nvidia-*
+	sudo apt-get autoremove -y
+	sudo apt-get autoclean
+	wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+	sudo dpkg -i cuda-keyring_1.1-1_all.deb
+	sudo apt-get update
+	echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+	sudo apt-get -y install cuda-12-6
+	sudo apt-get autoremove -y
+	sudo apt-get autoclean
+	#nvcc -V  # See updated CUDA versions
+	sudo update-alternatives --display cuda
+
+pt260: cu126
+	pip uninstall -y torch torchaudio torchvision
+	pip install "torch>=2.6.0,<2.7" torchaudio torchvision --index-url https://download.pytorch.org/whl/cu126

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,5 @@
-torch @ https://download.pytorch.org/whl/cu124/torch-2.5.1%2Bcu124-cp311-cp311-linux_x86_64.whl
-torchaudio @ https://download.pytorch.org/whl/cu124/torchaudio-2.5.1%2Bcu124-cp311-cp311-linux_x86_64.whl
-torchvision @ https://download.pytorch.org/whl/cu124/torchvision-0.20.1%2Bcu124-cp311-cp311-linux_x86_64.whl
+-f https://download.pytorch.org/whl/cu126
+torch==2.6.0+cu126
+torchaudio==2.6.0+cu126
+torchvision==0.21.0+cu126
 # torchtext  # Now we have to compile it manually


### PR DESCRIPTION
- related: implements #9 except py312

Main references for CUDA:
1. https://docs.nvidia.com/cuda/archive/12.6.3/cuda-installation-guide-linux/index.html#handle-conflicting-installation-methods
2. https://docs.nvidia.com/cuda/archive/12.6.3/cuda-installation-guide-linux/index.html#network-repo-installation-for-ubuntu
3. https://docs.nvidia.com/cuda/archive/12.6.3/cuda-installation-guide-linux/index.html#common-installation-instructions-for-ubuntu
4. https://docs.nvidia.com/cuda/archive/12.6.3/cuda-installation-guide-linux/index.html#meta-packages
5. https://docs.nvidia.com/deploy/cuda-compatibility/#id3
6. https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#ubuntu-installation-prepare (Not 100% feasible in Colab)